### PR TITLE
ToastをRecoilで管理 #46

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,6 +8,7 @@ import { ThemeProvider as MaterialUIThemeProvider } from '@material-ui/core/styl
 import { StylesProvider } from '@material-ui/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import { Dialogs } from '../root/components/Dialogs';
+import { Toast } from '../root/components/Toast';
 
 /**
  * クライアント側のレンダリングカスタマイズ
@@ -30,6 +31,7 @@ export default function App({ Component, pageProps }: AppProps) {
         <MaterialUIThemeProvider theme={theme}>
           <StyledComponentsThemeProvider theme={theme}>
             <CssBaseline />
+            <Toast />
             <Dialogs />
             <Component {...pageProps} />
           </StyledComponentsThemeProvider>

--- a/pages/forget.tsx
+++ b/pages/forget.tsx
@@ -1,9 +1,8 @@
-import React, { useState } from 'react';
+import React from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useForm } from 'react-hook-form';
 import { auth } from '../root/utils/firebase';
-import { Toast } from '../root/components/Toast';
 import { InputWithLabel } from '../root/components/InputWithLabel';
 import { CircularProgress, Typography } from '@material-ui/core';
 import {
@@ -11,6 +10,8 @@ import {
   AuthenticateContainer,
   StyledButton,
 } from '../styles/common';
+import { useSetRecoilState } from 'recoil';
+import { toastValue } from '../recoil/root';
 
 type FormData = {
   email: string;
@@ -18,11 +19,8 @@ type FormData = {
 
 const ForgetPassword = () => {
   const { register, handleSubmit, errors, formState } = useForm<FormData>();
-  const [open, setOpen] = useState(false);
-  const [errorMessage, setErrorMessage] = useState('');
+  const setToast = useSetRecoilState(toastValue);
   const router = useRouter();
-
-  const handleClose = () => setOpen(false);
 
   const handleSend = async ({ email }: FormData) => {
     try {
@@ -30,8 +28,7 @@ const ForgetPassword = () => {
       router.push('/signin');
     } catch (err) {
       if (err.code === 'auth/user-not-found') {
-        setOpen(true);
-        setErrorMessage('メールアドレスをお確かめください');
+        setToast(['メールアドレスをお確かめください', 'error']);
       }
     }
   };
@@ -66,16 +63,6 @@ const ForgetPassword = () => {
         </StyledButton>
         <Link href="/signin">戻る</Link>
       </AuthenticateForm>
-
-      {/* トースト */}
-      <Toast
-        vertical="top"
-        horizontal="center"
-        open={open}
-        serverity="error"
-        message={errorMessage}
-        handleClose={handleClose}
-      />
     </AuthenticateContainer>
   );
 };

--- a/pages/signin.tsx
+++ b/pages/signin.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import Link from 'next/link';
 import { CircularProgress } from '@material-ui/core';
 import {
@@ -10,9 +10,10 @@ import { useForm } from 'react-hook-form';
 import { auth } from '../root/utils/firebase';
 import styled from 'styled-components';
 import { sp } from '../styles/media';
-import { Toast } from '../root/components/Toast';
 import { InputWithLabel } from '../root/components/InputWithLabel';
 import { InputType } from '../types';
+import { useSetRecoilState } from 'recoil';
+import { toastValue } from '../recoil/root';
 
 type FormData = {
   email: string;
@@ -23,12 +24,7 @@ export default function SignIn() {
   const { register, handleSubmit, reset, errors, formState } = useForm<
     FormData
   >();
-  const [open, setOpen] = useState(false);
-  const [errorMessage, setErrorMessage] = useState('');
-
-  const handleClose = () => {
-    setOpen(false);
-  };
+  const setToast = useSetRecoilState(toastValue);
 
   /** サインイン */
   const handleSignIn = async (data: FormData) => {
@@ -38,11 +34,9 @@ export default function SignIn() {
       reset();
     } catch (err) {
       if (err.code === 'auth/user-not-found') {
-        setErrorMessage('メールアドレスが間違っています');
-        setOpen(true);
+        setToast(['メールアドレスが間違っています', 'error']);
       } else if (err.code === 'auth/wrong-password') {
-        setErrorMessage('パスワードが間違っています');
-        setOpen(true);
+        setToast(['パスワードが間違っています', 'error']);
       }
     }
   };
@@ -90,16 +84,6 @@ export default function SignIn() {
           <Link href="/signup">アカウントを持っていない方はこちら</Link>
         </AuthenticateLink>
       </AuthenticateForm>
-
-      {/* トースト */}
-      <Toast
-        vertical="top"
-        horizontal="center"
-        open={open}
-        serverity="error"
-        message={errorMessage}
-        handleClose={handleClose}
-      />
     </AuthenticateContainer>
   );
 }

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -10,9 +10,10 @@ import {
 import { useForm } from 'react-hook-form';
 import { auth, db } from '../root/utils/firebase';
 import firebase from 'firebase';
-import { Toast } from '../root/components/Toast';
 import { InputWithLabel } from '../root/components/InputWithLabel';
 import { InputType } from '../types';
+import { useSetRecoilState } from 'recoil';
+import { toastValue } from '../recoil/root';
 
 type FormData = {
   name: string;
@@ -26,8 +27,7 @@ export default function SignUp() {
     FormData
   >();
   const [isError, setIsError] = useState(false);
-  const [open, setOpen] = useState(false);
-  const [errorMessage, setErrorMessage] = useState('');
+  const setToast = useSetRecoilState(toastValue);
 
   /** メールアドレスとパスワードでユーザーを作成、名前も設定 */
   const createUser = async (email: string, password: string, name: string) => {
@@ -48,10 +48,6 @@ export default function SignUp() {
     });
   };
 
-  const handleClose = () => {
-    setOpen(false);
-  };
-
   /** Sign Up */
   const handleSignUp = async (data: FormData) => {
     try {
@@ -69,11 +65,9 @@ export default function SignUp() {
       reset();
     } catch (err) {
       if (err.code === 'auth/invalid-email') {
-        setErrorMessage('メールアドレスの書式をお確かめください');
-        setOpen(true);
+        setToast(['メールアドレスの書式をお確かめください', 'error']);
       } else if (err.code === 'auth/weak-password') {
-        setErrorMessage('パスワードが短すぎます');
-        setOpen(true);
+        setToast(['パスワードが短すぎます', 'error']);
       }
     }
   };
@@ -132,16 +126,6 @@ export default function SignUp() {
         </StyledButton>
         <Link href="/signin">既にアカウントをお持ちの方はこちら</Link>
       </AuthenticateForm>
-
-      {/* トースト */}
-      <Toast
-        vertical="top"
-        horizontal="center"
-        open={open}
-        serverity="error"
-        message={errorMessage}
-        handleClose={handleClose}
-      />
     </AuthenticateContainer>
   );
 }

--- a/recoil/root.tsx
+++ b/recoil/root.tsx
@@ -14,3 +14,10 @@ export const imageData = atom({
   key: 'imageData',
   default: '',
 });
+
+export type ToastType = [string, ('error' | 'info' | 'success' | 'warning')?];
+
+export const toastValue = atom<ToastType>({
+  key: 'toastValue',
+  default: [''],
+});

--- a/root/components/Toast.tsx
+++ b/root/components/Toast.tsx
@@ -1,34 +1,35 @@
-import React, { FC } from 'react';
 import { Snackbar } from '@material-ui/core';
 import { Alert } from '@material-ui/lab';
+import React, { useEffect } from 'react';
+import { useResetRecoilState } from 'recoil';
+import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
+import { toastValue } from '../../recoil/root';
 
-type Props = {
-  vertical: 'top' | 'bottom';
-  horizontal: 'left' | 'center' | 'right';
-  message: string;
-  open: boolean;
-  serverity: 'error' | 'warning' | 'info' | 'success';
-  handleClose: () => void;
-};
+export const Toast = () => {
+  const [text, severity] = useRecoilValue(toastValue);
+  const reset = useResetRecoilState(toastValue);
 
-export const Toast: FC<Props> = ({
-  vertical,
-  horizontal,
-  open,
-  message,
-  serverity,
-  handleClose,
-}) => {
+  useEffect(() => {
+    if (!text) return;
+
+    /** 3秒後に閉じる */
+    setTimeout(() => {
+      reset();
+    }, 3000);
+  }, [text]);
+
   return (
-    <StyledSnackbar
-      anchorOrigin={{ vertical, horizontal }}
-      open={open}
-      key={vertical + horizontal}
-      onClose={handleClose}
-    >
-      <Alert severity={serverity}>{message}</Alert>
-    </StyledSnackbar>
+    <>
+      {text && (
+        <StyledSnackbar
+          open
+          anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+        >
+          <Alert severity={severity}>{text}</Alert>
+        </StyledSnackbar>
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION
## Issue

Closes #46 


## 今回の PR で行ったこと

- Toastをrecoilで管理する
- 元々使ってたところを変更→State6個減り、レンダリング 範囲も減った👍 

## 動作確認(どのような動作確認を行ったのか？ 結果はどうか？)

- localhostでsigninをわざと失敗した時にトーストが表示されることを確認

## 影響範囲(行った作業によってどこまで影響が及ぶようになるか)

- 

## 実装するにあたって参考にした URL

- 

## 確認して欲しいこと

こんな感じでやりました↓

```ts
const setToast = useSetRecoilValue(toastValue);
setToast(['メッセージ'(:string 必須),'error'('error' | 'info' | 'success' | 'warning' 任意)])
```
- こんな感じで良いか

## 懸念点

- 



