### PR TITLE
スペース入力でも通ってしまうのを修正 #37

### DIFF
--- a/pages/signin.tsx
+++ b/pages/signin.tsx
@@ -66,7 +66,13 @@ export default function SignIn() {
       label: 'パスワード',
       error: errors.password,
       type: 'password',
-      inputRef: register({ required: 'パスワードを入力してください' }),
+      inputRef: register({
+        required: 'パスワードを入力してください',
+        pattern: {
+          value: /[^ |　]/,
+          message: 'スペースのみの入力はできません。',
+        },
+      }),
     },
   ];
 

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -83,7 +83,13 @@ export default function SignUp() {
       name: 'name',
       label: '名前',
       error: errors.name,
-      inputRef: register({ required: '名前を入力してください' }),
+      inputRef: register({
+        required: '名前を入力してください',
+        pattern: {
+          value: /[^ |　]/,
+          message: 'スペースのみの入力はできません。',
+        },
+      }),
     },
     {
       name: 'email',
@@ -103,14 +109,26 @@ export default function SignUp() {
       label: 'パスワード',
       error: errors.password,
       type: 'password',
-      inputRef: register({ required: 'パスワードを入力してください' }),
+      inputRef: register({
+        required: 'パスワードを入力してください',
+        pattern: {
+          value: /[^ |　]/,
+          message: 'スペースのみの入力はできません。',
+        },
+      }),
     },
     {
       name: 'passwordConfirm',
       label: 'パスワード再確認',
       error: errors.passwordConfirm,
       type: 'password',
-      inputRef: register({ required: 'パスワード再確認を入力してください' }),
+      inputRef: register({
+        required: 'パスワード再確認を入力してください',
+        pattern: {
+          value: /[^ |　]/,
+          message: 'スペースのみの入力はできません。',
+        },
+      }),
     },
   ];
 

--- a/root/components/AddBlogDialog.tsx
+++ b/root/components/AddBlogDialog.tsx
@@ -56,6 +56,10 @@ export const AddBlogDialog = () => {
       error: errors.title,
       inputRef: register({
         required: '必須項目です',
+        pattern: {
+          value: /[^ |　]/,
+          message: 'スペースのみの入力はできません。',
+        },
       }),
     },
     {
@@ -76,7 +80,13 @@ export const AddBlogDialog = () => {
       variant: 'outlined',
       multiline: true,
       rows: 5,
-      inputRef: register,
+      error: errors.memo,
+      inputRef: register({
+        pattern: {
+          value: /[^ |　]/,
+          message: 'スペースのみの入力はできません。',
+        },
+      }),
     },
   ];
 

--- a/root/components/AddCategoryDialog.tsx
+++ b/root/components/AddCategoryDialog.tsx
@@ -66,6 +66,10 @@ export const AddCategoryDialog = () => {
         name="category"
         inputRef={register({
           required: '必須項目です',
+          pattern: {
+            value: /[^ |　]/,
+            message: 'スペースのみの入力はできません。',
+          },
         })}
         error={errors.category}
         label="カテゴリー名*"


### PR DESCRIPTION
## Issue

Closes #37 


## 今回の PR で行ったこと

- 正規表現でスペースのみの入力をできないようにした

## 動作確認(どのような動作確認を行ったのか？ 結果はどうか？)

- signin,signup,blog追加など

![image](https://user-images.githubusercontent.com/61049074/99079381-37ed7b80-2603-11eb-9076-28649590f333.png)


## 影響範囲(行った作業によってどこまで影響が及ぶようになるか)

- input系

## 実装するにあたって参考にした URL

- [基本的な正規表現一覧](https://murashun.jp/blog/20190215-01.html)

## 確認して欲しいこと

- 変更点が正しいか

## 懸念点

- 



