### PR TITLE
alertのところをToastに移行 #49

### DIFF
--- a/root/components/AddBlogDialog.tsx
+++ b/root/components/AddBlogDialog.tsx
@@ -11,6 +11,8 @@ import { Checkbox } from '@material-ui/core';
 import { ADD_BLOG } from '../../recoil/dialog';
 import firebase, { auth, db } from '../utils/firebase';
 import { Label, LabelText } from '../../styles/common';
+import { useSetRecoilState } from 'recoil';
+import { toastValue } from '../../recoil/root';
 
 export const AddBlogDialog = () => {
   const { register, errors, handleSubmit, reset } = useForm<FormValues>();
@@ -18,9 +20,9 @@ export const AddBlogDialog = () => {
   const [category, setCategory] = useState<Category | null>(null);
   const [isPublic, setIsPublic] = useState(false);
   const user = auth.currentUser;
+  const setToast = useSetRecoilState(toastValue);
 
   const onSubmit = async (data: FormValues) => {
-    console.log(data);
     try {
       await db.collection('blog').add({
         title: data.title,
@@ -39,13 +41,13 @@ export const AddBlogDialog = () => {
       //(連続で追加する場合によくないので)
       const res = await db.collection('tags').get();
       res.docs.map((doc) => doc.ref.update({ isChecked: false }));
-      alert('追加出来ました！');
+      setToast(['追加出来ました！']);
       setCategory(null);
       setTag([]);
       setIsPublic(false);
       reset();
     } catch (error) {
-      console.log(error);
+      setToast(['追加に失敗しました','error'])
     }
   };
 

--- a/root/components/AddCategoryDialog.tsx
+++ b/root/components/AddCategoryDialog.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { useRecoilState } from 'recoil';
-import { imageData } from '../../recoil/root';
+import { useRecoilState, useSetRecoilState } from 'recoil';
+import { imageData, toastValue } from '../../recoil/root';
 import { ImageUpload } from '../utils/ImageUpload';
 import { auth, db, storage } from '../utils/firebase';
 
@@ -25,6 +25,7 @@ export const AddCategoryDialog = () => {
   const [imageUrl, setImageUrl] = useRecoilState(imageData);
   const user = auth.currentUser;
   const { register, errors, handleSubmit, reset } = useForm<FormData>();
+  const setToast = useSetRecoilState(toastValue);
 
   const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files) {
@@ -41,18 +42,18 @@ export const AddCategoryDialog = () => {
   const onSubmit = async (data: FormData) => {
     try {
       if (categoryList.find((db) => db.name === data.category)) {
-        return alert('カテゴリー名が存在します');
+        return setToast(['カテゴリー名が存在します', 'error']);
       }
       await db.collection('categoryList').add({
         name: data.category,
         imageUrl,
         createdUser: db.collection('users').doc(user?.uid),
       });
-      alert('追加出来ました！');
+      setToast(['追加出来ました！']);
       reset();
       setImageUrl('');
     } catch (err) {
-      console.log(err);
+      setToast(['追加に失敗しました', 'error']);
     }
   };
 

--- a/root/components/SettingMenu.tsx
+++ b/root/components/SettingMenu.tsx
@@ -4,6 +4,8 @@ import { useRouter } from 'next/dist/client/router';
 //material
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
+import { toastValue } from '../../recoil/root';
+import { useSetRecoilState } from 'recoil';
 
 type Props = {
   open: null | HTMLElement;
@@ -13,12 +15,14 @@ type Props = {
 export const SettingMenu: FC<Props> = ({ open, onClose }) => {
   const router = useRouter();
   const user = auth.currentUser;
+  const setToast = useSetRecoilState(toastValue);
+
   const handleAction = async () => {
     if (user) {
       try {
         await auth.signOut();
       } catch {
-        alert('サインアウトに失敗しました');
+        setToast(['サインアウトに失敗しました']);
       }
     } else {
       router.push('/signin');

--- a/root/components/SignInWithSns.tsx
+++ b/root/components/SignInWithSns.tsx
@@ -2,15 +2,19 @@ import React from 'react';
 import firebase, { auth, db, providerGoogle } from '../utils/firebase';
 import styled from 'styled-components';
 import Image from 'next/image';
+import { toastValue } from '../../recoil/root';
+import { useSetRecoilState } from 'recoil';
 
 export const SignInWithSns = () => {
+  const setToast = useSetRecoilState(toastValue);
+
   const googleLogin = async () => {
     try {
       const res = await auth.signInWithPopup(providerGoogle);
       console.log(res);
       snsLoginResponse(res);
     } catch (error) {
-      console.error(error);
+      setToast(['ログインに失敗しました', 'error']);
     }
   };
 
@@ -23,7 +27,7 @@ export const SignInWithSns = () => {
         id: user?.uid,
       });
     } catch (error) {
-      console.error(error);
+      setToast(['ログインに失敗しました', 'error']);
     }
   };
 

--- a/root/components/Toast.tsx
+++ b/root/components/Toast.tsx
@@ -14,9 +14,13 @@ export const Toast = () => {
     if (!text) return;
 
     /** 3秒後に閉じる */
-    setTimeout(() => {
+    const closeTime = setTimeout(() => {
       reset();
     }, 3000);
+    // clean up
+    return () => {
+      clearTimeout(closeTime);
+    };
   }, [text]);
 
   return (
@@ -25,6 +29,7 @@ export const Toast = () => {
         <StyledSnackbar
           open
           anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+          onClose={reset}
         >
           <Alert severity={severity}>{text}</Alert>
         </StyledSnackbar>


### PR DESCRIPTION
## Issue

Closes #49 


## 今回の PR で行ったこと

- 見た感じアラートにしなきゃいけなさそうなのはなかったので、アラートを全部トーストにしました
- 画面タッチでトーストが消えるようにして、clean up追加

## 動作確認(どのような動作確認を行ったのか？ 結果はどうか？)

- signinなどで失敗する

## 影響範囲(行った作業によってどこまで影響が及ぶようになるか)

- 

## 実装するにあたって参考にした URL

- 

## 確認して欲しいこと

- 変更箇所がトーストで問題ないか

## 懸念点

- 



