### PR TITLE
add: カテゴリーのlistボタン押下でblogListへ遷移 etc

### DIFF
--- a/recoil/root.tsx
+++ b/recoil/root.tsx
@@ -1,6 +1,8 @@
 import { atom } from 'recoil';
 
-export const currentDisplayData = atom<'list' | 'category'>({
+export const currentDisplayData = atom<
+  'list' | 'category' | 'yet' | 'done' | 'userCategoryBlog' | 'myCategoryBlog'
+>({
   key: 'currentDisplayData',
   default: 'list',
 });

--- a/root/components/AddBlogDialog.tsx
+++ b/root/components/AddBlogDialog.tsx
@@ -39,6 +39,7 @@ export const AddBlogDialog = () => {
         isPrivate,
         postedUser: user?.uid,
         postedAt: firebase.firestore.Timestamp.now(),
+        isDone: false,
       });
 
       const res = await db.collection('tags').get();

--- a/root/components/AddCategoryDialog.tsx
+++ b/root/components/AddCategoryDialog.tsx
@@ -78,6 +78,7 @@ export const AddCategoryDialog = () => {
           accept="image/*"
           multiple
           type="file"
+          id="contained-button-file"
           onChange={handleImageUpload}
         />
         <label htmlFor="contained-button-file">

--- a/root/components/DeleteButton.tsx
+++ b/root/components/DeleteButton.tsx
@@ -23,6 +23,7 @@ export const DeleteButton: FC<Props> = ({ id, type }) => {
       const res = await db.doc(`${type}/${id}`).get();
       const otherUserBlogId: string = res.data()?.otherUserBlogId;
       db.doc(`blog/${otherUserBlogId}/laterReadUsers/${user?.uid}`).delete();
+
       await db.collection(type).doc(id).delete();
 
       if (type === 'myCategory') {

--- a/root/components/SettingMenu.tsx
+++ b/root/components/SettingMenu.tsx
@@ -1,11 +1,10 @@
 import React, { FC } from 'react';
 import { auth } from '../utils/firebase';
 import { useRouter } from 'next/dist/client/router';
-//material
-import Menu from '@material-ui/core/Menu';
-import MenuItem from '@material-ui/core/MenuItem';
 import { toastState } from '../../recoil/root';
 import { useSetRecoilState } from 'recoil';
+//material
+import { Menu, MenuItem } from '@material-ui/core';
 
 type Props = {
   open: null | HTMLElement;

--- a/root/components/Tag.tsx
+++ b/root/components/Tag.tsx
@@ -15,7 +15,7 @@ type Props = {
   autoOption?: FormValues[];
 };
 
-export const Tag: FC<Props> = ({ tag, setTag, autoOption }) => {
+export const Tag: FC<Props> = ({ tag, setTag }) => {
   const tags = useCollection<Tags>('tags');
   const [inputValue, setInputValue] = useState('');
 

--- a/root/components/Toast.tsx
+++ b/root/components/Toast.tsx
@@ -1,9 +1,8 @@
+import React, { useEffect } from 'react';
+import { useResetRecoilState, useRecoilValue } from 'recoil';
+import { toastState } from '../../recoil/root';
 import { Snackbar } from '@material-ui/core';
 import { Alert } from '@material-ui/lab';
-import React, { useEffect } from 'react';
-import { useResetRecoilState } from 'recoil';
-import { useRecoilValue } from 'recoil';
-import { toastState } from '../../recoil/root';
 
 export const Toast = () => {
   const [text, severity] = useRecoilValue(toastState);

--- a/root/pages/main/components/BlogItem.tsx
+++ b/root/pages/main/components/BlogItem.tsx
@@ -15,6 +15,8 @@ import {
   CardMedia,
   Grid,
   Typography,
+  Checkbox,
+  Tooltip,
 } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import { purple } from '@material-ui/core/colors';
@@ -24,9 +26,6 @@ import StarRoundedIcon from '@material-ui/icons/StarRounded';
 import BookmarkRoundedIcon from '@material-ui/icons/BookmarkRounded';
 
 const useStyles = makeStyles((theme) => ({
-  icon: {
-    marginRight: theme.spacing(2),
-  },
   card: {
     height: '100%',
     display: 'flex',
@@ -38,9 +37,11 @@ const useStyles = makeStyles((theme) => ({
   cardContent: {
     flexGrow: 1,
   },
-  ButtonColor: {
-    color: purple[200],
-    border: `1px ${purple[200]} solid`,
+  moveCard: {
+    transitionDuration: '0.5s',
+    '&:hover': {
+      transform: 'scale(1.1,1.1)',
+    },
   },
 }));
 
@@ -49,6 +50,7 @@ type Props = {
   iconSwitch: (id: string, type: 'favUsers' | 'laterReadUsers') => void;
   id: string;
   isDisplay: boolean;
+  isDone: boolean;
   memo: string;
   tag: string[];
   title: string;
@@ -59,6 +61,7 @@ export const BlogItem: FC<Props> = ({
   iconSwitch,
   id,
   isDisplay,
+  isDone,
   memo,
   tag,
   title,
@@ -68,6 +71,7 @@ export const BlogItem: FC<Props> = ({
   const setDialog = useSetRecoilState(dialogData);
   const [isFav, setIsFav] = useState(false);
   const [isHoldLaterRead, setIsHoldLaterRead] = useState(false);
+  const [isReadCheck, setIsReadCheck] = useState(false);
 
   useEffect(() => {
     if (user) {
@@ -80,8 +84,12 @@ export const BlogItem: FC<Props> = ({
     }
   }, [user]);
 
+  const isDoneUpdate = (id: string) => {
+    setIsReadCheck(!isReadCheck);
+    db.collection('blog').doc(id).update({ isDone: !isReadCheck });
+  };
   return (
-    <Grid item key={id} xs={12} sm={6} md={4}>
+    <Grid item key={id} xs={12} sm={6} md={4} className={classes.moveCard}>
       <Card className={classes.card}>
         <CardMedia
           className={classes.cardMedia}
@@ -111,6 +119,16 @@ export const BlogItem: FC<Props> = ({
                   edit
                 </Button>
               </Link>
+              <Tooltip title={isReadCheck ? 'read' : 'Not read'}>
+                <Checkbox
+                  size="small"
+                  color="default"
+                  checked={isDone}
+                  onClick={() => {
+                    isDoneUpdate(id);
+                  }}
+                />
+              </Tooltip>
               <DeleteButton type="blog" id={id} />
             </>
           )}
@@ -163,11 +181,12 @@ const StyleTag = styled.div`
   margin: 2px;
   display: inline-block;
   padding: 4px 12px;
-  border: 1px solid ${COLOR.MAIN};
   text-transform: uppercase;
   font-family: sans-serif;
   font-size: 8px;
+  color: white;
   font-weight: 800;
   letter-spacing: 1px;
   background: linear-gradient(45deg, #afeeee 10%, #40e0d0 30%, #20b2aa 80%);
+  border-radius: 50px;
 `;

--- a/root/pages/main/components/BlogList.tsx
+++ b/root/pages/main/components/BlogList.tsx
@@ -30,6 +30,7 @@ export const BlogList: FC<Props> = ({ data, iconSwitch, isDisplay }) => {
             iconSwitch={iconSwitch}
             id={card.id}
             isDisplay={isDisplay}
+            isDone={card.isDone}
             memo={card.memo}
             tag={card.tag}
             title={card.title}

--- a/root/pages/main/components/CategoryItem.tsx
+++ b/root/pages/main/components/CategoryItem.tsx
@@ -1,6 +1,8 @@
 import React, { FC } from 'react';
 import { FormValues } from '../../../../types';
 import Link from 'next/link';
+import { useSetRecoilState } from 'recoil';
+import { currentDisplayData, toastState } from '../../../../recoil/root';
 // material
 import {
   Button,
@@ -29,6 +31,12 @@ const useStyles = makeStyles((theme) => ({
   cardContent: {
     flexGrow: 1,
   },
+  moveCard: {
+    transitionDuration: '0.5s',
+    '&:hover': {
+      transform: 'scale(1.1,1.1)',
+    },
+  },
 }));
 
 type Props = {
@@ -37,6 +45,7 @@ type Props = {
   id: string;
   imageUrl: string;
   name: string;
+  setSelectCategory: (param: string) => void;
 };
 
 export const CategoryItem: FC<Props> = ({
@@ -45,18 +54,33 @@ export const CategoryItem: FC<Props> = ({
   id,
   imageUrl,
   name,
+  setSelectCategory,
 }) => {
   const classes = useStyles();
+  const setCurrentPage = useSetRecoilState(currentDisplayData);
+  const setToast = useSetRecoilState(toastState);
 
-  const categoryHoldBlog = blogData
-    .filter((blog) => blog.category === name)
-    .filter((blog) => !blog.otherUserBlogId);
+  const categoryHoldBlog = blogData.filter(
+    (blog) => blog.category === name && !blog.otherUserBlogId && !blog.isPrivate
+  );
   const myCategoryHoldBlog = blogData.filter(
     (blog) => blog.myCategory === name
   );
 
+  const categoryHasBlog = (name: string) => {
+    if (activePage === 'user' && categoryHoldBlog.length) {
+      setCurrentPage('userCategoryBlog');
+      setSelectCategory(name);
+    } else if (activePage === 'my' && myCategoryHoldBlog.length) {
+      setCurrentPage('myCategoryBlog');
+      setSelectCategory(name);
+    } else {
+      return setToast(['ブログはありません', 'error']);
+    }
+  };
+
   return (
-    <Grid item key={id} xs={12} sm={6} md={4}>
+    <Grid item key={id} xs={12} sm={6} md={4} className={classes.moveCard}>
       <Card className={classes.card}>
         <CardMedia
           className={classes.cardMedia}
@@ -74,7 +98,13 @@ export const CategoryItem: FC<Props> = ({
           </Typography>
         </CardContent>
         <CardActions>
-          <Button size="small" color="primary">
+          <Button
+            size="small"
+            color="primary"
+            onClick={() => {
+              categoryHasBlog(name);
+            }}
+          >
             list
           </Button>
           {activePage === 'my' && (

--- a/root/pages/main/components/CategoryList.tsx
+++ b/root/pages/main/components/CategoryList.tsx
@@ -16,9 +16,15 @@ type Props = {
   activePage: 'my' | 'user';
   blogData: FormValues[];
   data: Category[];
+  setSelectCategory: (param: string) => void;
 };
 
-export const CategoryList: FC<Props> = ({ activePage, blogData, data }) => {
+export const CategoryList: FC<Props> = ({
+  activePage,
+  blogData,
+  data,
+  setSelectCategory,
+}) => {
   const classes = useStyles();
 
   return (
@@ -32,6 +38,7 @@ export const CategoryList: FC<Props> = ({ activePage, blogData, data }) => {
             id={card.id}
             imageUrl={card.imageUrl}
             name={card.name}
+            setSelectCategory={setSelectCategory}
           />
         ))}
       </Grid>

--- a/root/pages/main/components/PageTop.tsx
+++ b/root/pages/main/components/PageTop.tsx
@@ -1,17 +1,25 @@
 import React, { FC } from 'react';
-import { useRecoilState } from 'recoil';
-import { currentDisplayData } from '../../../../recoil/root';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import {
+  currentDisplayData,
+  activeDisplayData,
+  toastState,
+} from '../../../../recoil/root';
 //material
-import Button from '@material-ui/core/Button';
-import Grid from '@material-ui/core/Grid';
-import Container from '@material-ui/core/Container';
+import {
+  Button,
+  Grid,
+  Container,
+  Paper,
+  InputBase,
+  Typography,
+} from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
-import Paper from '@material-ui/core/Paper';
-import InputBase from '@material-ui/core/InputBase';
+import { cyan } from '@material-ui/core/colors';
 import IconButton from '@material-ui/core/IconButton';
 import SearchIcon from '@material-ui/icons/Search';
-import Typography from '@material-ui/core/Typography';
-import { cyan } from '@material-ui/core/colors';
+import CheckCircleOutlineRoundedIcon from '@material-ui/icons/CheckCircleOutlineRounded';
+import LocalLibraryRoundedIcon from '@material-ui/icons/LocalLibraryRounded';
 
 const useStyles = makeStyles((theme) => ({
   heroContent: {
@@ -21,7 +29,6 @@ const useStyles = makeStyles((theme) => ({
   heroButtons: {
     marginTop: theme.spacing(4),
   },
-
   inputRoot: {
     padding: '2px 4px',
     display: 'flex',
@@ -38,21 +45,32 @@ const useStyles = makeStyles((theme) => ({
   themeColor: {
     backgroundColor: cyan[700],
     color: 'white',
-  },
-  currentColor: {
-    backgroundColor: cyan[500],
+    border: '1px solid white',
+    '&:hover': {
+      backgroundColor: cyan[600],
+    },
   },
 }));
 
 type Props = {
   title: string;
+  categoryLength?: number;
+  yetBlogLength?: number;
+  doneBlogLength?: number;
 };
 
-export const PageTop: FC<Props> = ({ title }) => {
+export const PageTop: FC<Props> = ({
+  title,
+  categoryLength,
+  yetBlogLength,
+  doneBlogLength,
+}) => {
   const classes = useStyles();
   const [currentDisplay, setCurrentDisplay] = useRecoilState(
     currentDisplayData
   );
+  const activePage = useRecoilValue(activeDisplayData);
+  const setToast = useSetRecoilState(toastState);
 
   return (
     <div className={classes.heroContent}>
@@ -82,34 +100,68 @@ export const PageTop: FC<Props> = ({ title }) => {
           <Grid container spacing={2} justify="center">
             <Grid item>
               <Button
-                variant="contained"
-                className={
-                  currentDisplay === 'list'
-                    ? classes.themeColor
-                    : classes.currentColor
-                }
+                variant="outlined"
                 onClick={() => {
                   setCurrentDisplay('list');
                 }}
+                className={currentDisplay === 'list' ? classes.themeColor : ''}
               >
-                list
+                一覧
               </Button>
             </Grid>
             <Grid item>
               <Button
-                variant="contained"
-                className={
-                  currentDisplay === 'category'
-                    ? classes.themeColor
-                    : classes.currentColor
-                }
+                variant="outlined"
                 onClick={() => {
                   setCurrentDisplay('category');
+                  if (!categoryLength && activePage === 'my')
+                    setToast(['カテゴリーがありません', 'warning']);
                 }}
+                className={
+                  currentDisplay === 'category' ? classes.themeColor : ''
+                }
               >
-                category
+                カテゴリー別
               </Button>
             </Grid>
+          </Grid>
+          <Grid container spacing={2} justify="center">
+            {activePage === 'my' && (
+              <>
+                <Grid item>
+                  <Button
+                    variant="outlined"
+                    onClick={() => {
+                      setCurrentDisplay('yet');
+                      if (!yetBlogLength && activePage === 'my')
+                        setToast(['未読ブログはありません', 'warning']);
+                    }}
+                    className={
+                      currentDisplay === 'yet' ? classes.themeColor : ''
+                    }
+                  >
+                    未読
+                    <LocalLibraryRoundedIcon />
+                  </Button>
+                </Grid>
+                <Grid item>
+                  <Button
+                    variant="outlined"
+                    onClick={() => {
+                      setCurrentDisplay('done');
+                      if (!doneBlogLength && activePage === 'my')
+                        setToast(['読み終えたブログはありません', 'warning']);
+                    }}
+                    className={
+                      currentDisplay === 'done' ? classes.themeColor : ''
+                    }
+                  >
+                    読了
+                    <CheckCircleOutlineRoundedIcon />
+                  </Button>
+                </Grid>
+              </>
+            )}
           </Grid>
         </div>
       </Container>

--- a/root/pages/main/index.tsx
+++ b/root/pages/main/index.tsx
@@ -26,7 +26,8 @@ const Main: FC = () => {
   const categoryList = useCollection<Category>('categoryList');
   const currentDisplay = useRecoilValue(currentDisplayData);
   const [activePage, setActivePage] = useRecoilState(activeDisplayData);
-  const [filterBlog, setFilterBlog] = useState<FormValues[]>([]);
+  const [onlyMyBlog, setOnlyMyBlog] = useState<FormValues[]>([]);
+  const [selectCategory, setSelectCategory] = useState('');
 
   useEffect(() => {
     if (user) {
@@ -39,7 +40,7 @@ const Main: FC = () => {
               id: doc.id,
             };
           });
-          setFilterBlog(docData);
+          setOnlyMyBlog(docData);
         });
     }
   }, [user]);
@@ -119,19 +120,57 @@ const Main: FC = () => {
       : ADD_CATEGORY
     : RECOMMEND_REGISTER;
 
+  const switchMyPageDisplay = (
+    currentPage: 'list' | 'yet' | 'done' | 'userCategoryBlog' | 'myCategoryBlog'
+  ) => {
+    switch (currentPage) {
+      case 'yet':
+        return onlyMyBlog.filter((item) => !item.isDone);
+      case 'done':
+        return onlyMyBlog.filter((item) => item.isDone);
+      case 'myCategoryBlog':
+        return onlyMyBlog.filter((item) => item.myCategory === selectCategory);
+      case 'list':
+        return onlyMyBlog;
+      default:
+        return;
+    }
+  };
+
+  const switchUserPageDisplay = (
+    currentPage: 'list' | 'yet' | 'done' | 'userCategoryBlog' | 'myCategoryBlog'
+  ) => {
+    switch (currentPage) {
+      case 'userCategoryBlog':
+        return blog?.filter(
+          (display) =>
+            !display?.isPrivate &&
+            !display.otherUserBlogId &&
+            display.category === selectCategory
+        );
+      default:
+        return blog?.filter(
+          (display) => !display?.isPrivate && !display.otherUserBlogId
+        );
+    }
+  };
+
   return (
     <>
       <Header />
       <main>
-        <PageTop title={currentDisplay} />
-        {currentDisplay === 'list' ? (
+        <PageTop
+          title={currentDisplay}
+          categoryLength={myCategory.length}
+          yetBlogLength={onlyMyBlog.filter((item) => !item.isDone).length}
+          doneBlogLength={onlyMyBlog.filter((item) => item.isDone).length}
+        />
+        {currentDisplay !== 'category' ? (
           <BlogList
             data={
               user && activePage === 'my'
-                ? filterBlog
-                : blog
-                    ?.filter((display) => !display?.isPrivate)
-                    ?.filter((display) => !display.otherUserBlogId)
+                ? switchMyPageDisplay(currentDisplay)
+                : switchUserPageDisplay(currentDisplay)
             }
             iconSwitch={iconSwitch}
             isDisplay={user && activePage === 'my' ? true : false}
@@ -139,8 +178,9 @@ const Main: FC = () => {
         ) : (
           <CategoryList
             activePage={activePage}
-            blogData={activePage === 'my' ? filterBlog : blog}
+            blogData={activePage === 'my' ? onlyMyBlog : blog}
             data={activePage === 'my' ? myCategory : categoryList}
+            setSelectCategory={setSelectCategory}
           />
         )}
       </main>

--- a/types.tsx
+++ b/types.tsx
@@ -13,6 +13,7 @@ export type FormValues = {
   postedUser?: string;
   favCount: number;
   otherUserBlogId?: string;
+  isDone: boolean;
 };
 
 export type Tags = {


### PR DESCRIPTION
## Issue

Closes #63 
Closes #75 
Closes #30 

## 今回の PR で行ったこと

- カテゴリーのlist押下でページ遷移
- myPageのブログリストに未読/読了のチェックボックス追加
- myPageのブログリストに未読/読了ボタン追加 -> 切替実装
- タグスタイルぷち修正

## 動作確認(どのような動作確認を行ったのか？ 結果はどうか？)

- listボタン押したら分類されてるブログのみ表示されるか -> ok
- チェックボックスにチェック入れたら読了に振り分けられるか(逆も然り) -> ok

## 影響範囲(行った作業によってどこまで影響が及ぶようになるか)

- categorylist
- bloglist

## 実装するにあたって参考にした URL

- 

## 確認して欲しいこと

- 

## 懸念点

- mypageのカテゴリー解決できないままです（ ; ; ）
- myPageに追加したボタンのスタイル😇💦

