### PR TITLE
add:優先度セレクター追加

### DIFF
--- a/pages/blogedit/[id].tsx
+++ b/pages/blogedit/[id].tsx
@@ -4,18 +4,17 @@ import { useForm } from 'react-hook-form';
 import { useSetRecoilState } from 'recoil';
 import { toastState } from '../../recoil/root';
 import { Category, FormValues, InputType } from '../../types';
-import { Label, LabelText } from '../../styles/common';
 //component
 import { CategorySelector } from '../../root/components/CategorySelector';
 import { InputWithLabel } from '../../root/components/InputWithLabel';
 import { Tag } from '../../root/components/Tag';
 import { EditBase } from '../../root/components/EditBase';
+import { PrioritySelector } from '../../root/components/PrioritySelector';
+import { PrivateCheck } from '../../root/components/PrivateCheck';
 //utils
 import { db } from '../../root/utils/firebase';
 import { useCollection } from '../../root/utils/hooks';
 import { NORMAL_VALIDATION, URL_VALIDATION } from '../../root/utils/validation';
-//material
-import { Checkbox } from '@material-ui/core';
 
 const EditBlog = () => {
   const router = useRouter();
@@ -23,14 +22,15 @@ const EditBlog = () => {
   const { register, errors, handleSubmit, reset } = useForm<FormValues>({
     mode: 'onBlur',
   });
-
   const blog = useCollection<FormValues>('blog');
   const categoryList = useCollection<Category>('categoryList');
   const [tag, setTag] = useState<string[]>([]);
   const [category, setCategory] = useState<Category | null>(null);
   const [isPrivate, setIsPrivate] = useState(false);
   const [publicCategory, setPublicCategory] = useState('');
+  const [priority, setPriority] = useState<'0' | '1' | '2' | '3' | null>(null);
   const setToast = useSetRecoilState(toastState);
+
   const targetBlog = blog.find((db) => db.id === id);
   const targetCategory = categoryList.find((category) =>
     blog.find((db) => db.category === category.name)
@@ -52,12 +52,14 @@ const EditBlog = () => {
     if (targetBlog) {
       setIsPrivate(targetBlog.isPrivate);
       setTag(targetBlog.tag);
+      setPriority(targetBlog.priority);
     }
   }, [targetBlog]);
 
   useEffect(() => {
     if (targetCategory) setCategory(targetCategory);
   }, [targetCategory]);
+
   // ------useEffect[end]------
 
   const upDateValidation = (data: FormValues) => {
@@ -131,16 +133,10 @@ const EditBlog = () => {
         publicCategory={publicCategory}
       />
       <Tag tag={tag} setTag={setTag} />
-      <Label>
-        <label css="display: flex">
-          <LabelText>非公開</LabelText>
-          <Checkbox
-            color="primary"
-            checked={isPrivate}
-            onChange={(e) => setIsPrivate(e.target.checked)}
-          />
-        </label>
-      </Label>
+      <label css="display: flex">
+        <PrivateCheck {...{ isPrivate, setIsPrivate }} />
+        <PrioritySelector {...{ priority, setPriority }} />
+      </label>
     </EditBase>
   );
 };

--- a/pages/blogedit/[id].tsx
+++ b/pages/blogedit/[id].tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router';
 import { useForm } from 'react-hook-form';
 import { useSetRecoilState } from 'recoil';
 import { toastState } from '../../recoil/root';
-import { Category, FormValues, InputType } from '../../types';
+import { Category, FormValues, InputType, PriorityType } from '../../types';
 //component
 import { CategorySelector } from '../../root/components/CategorySelector';
 import { InputWithLabel } from '../../root/components/InputWithLabel';
@@ -28,7 +28,7 @@ const EditBlog = () => {
   const [category, setCategory] = useState<Category | null>(null);
   const [isPrivate, setIsPrivate] = useState(false);
   const [publicCategory, setPublicCategory] = useState('');
-  const [priority, setPriority] = useState<'0' | '1' | '2' | '3' | null>(null);
+  const [priority, setPriority] = useState<PriorityType>(null);
   const setToast = useSetRecoilState(toastState);
 
   const targetBlog = blog.find((db) => db.id === id);
@@ -85,12 +85,14 @@ const EditBlog = () => {
       upDateValidation(data);
 
       if (typeof id === 'string') {
-        if (category)
+        if (category) {
           await db.collection('blog').doc(id).update({
             category: publicCategory,
           });
+        }
         await db.collection('blog').doc(id).update({
           isPrivate,
+          priority,
         });
       }
       setToast(['変更出来ました！']);

--- a/pages/forget.tsx
+++ b/pages/forget.tsx
@@ -9,6 +9,7 @@ import { useSetRecoilState } from 'recoil';
 import { toastState } from '../recoil/root';
 import { LoadingButton } from '../root/components/LoadingButton';
 import { EMAIL_VALIDATION } from '../root/utils/validation';
+import ArrowBackIcon from '@material-ui/icons/ArrowBack';
 
 type FormData = {
   email: string;
@@ -35,7 +36,9 @@ export default function ForgetPassword() {
       <h1>パスワード再設定</h1>
       <form onSubmit={handleSubmit(handleSend)}>
         <p css="font-size: 16px; line-height: 1.75">
-          アカウントに関連付けられているメールアドレスを入力すると、パスワードをリセットするためのリンクが記載されたメールが送信されます。
+          登録されたアドレスを入力してください。
+          <br />
+          パスワードをリセットする為のリンクが記載されたメールが送信されます。
         </p>
         <InputWithLabel
           label="メールアドレス"
@@ -52,7 +55,9 @@ export default function ForgetPassword() {
         >
           送信
         </LoadingButton>
-        <Link href="/signin">戻る</Link>
+        <Link href="/signin">
+          <ArrowBackIcon css="cursor: pointer" />
+        </Link>
       </form>
     </AuthenticateContainer>
   );

--- a/root/components/AddBlogDialog.tsx
+++ b/root/components/AddBlogDialog.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { FormValues, InputType } from '../../types';
+import { FormValues, InputType, PriorityType } from '../../types';
 //recoil
 import { useSetRecoilState } from 'recoil';
 import { ADD_BLOG } from '../../recoil/dialog';
@@ -26,7 +26,7 @@ export const AddBlogDialog = () => {
   const [tag, setTag] = useState<string[]>([]);
   const [isPrivate, setIsPrivate] = useState(false);
   const [publicCategory, setPublicCategory] = useState('');
-  const [priority, setPriority] = useState<'0' | '1' | '2' | '3' | null>(null);
+  const [priority, setPriority] = useState<PriorityType>(null);
 
   const onSubmit = async (data: FormValues) => {
     try {

--- a/root/components/AddBlogDialog.tsx
+++ b/root/components/AddBlogDialog.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { FormValues, InputType } from '../../types';
-import { Label, LabelText } from '../../styles/common';
 //recoil
 import { useSetRecoilState } from 'recoil';
 import { ADD_BLOG } from '../../recoil/dialog';
@@ -11,21 +10,23 @@ import { DialogBase } from '../components/DialogBase';
 import { Tag } from '../components/Tag';
 import { InputWithLabel } from '../components/InputWithLabel';
 import { CategorySelector } from './CategorySelector';
+import { PrioritySelector } from './PrioritySelector';
+import { PrivateCheck } from './PrivateCheck';
 //utils
 import firebase, { auth, db } from '../utils/firebase';
 import { NORMAL_VALIDATION, REQUIRED_VALIDATION } from '../utils/validation';
 //material
-import { Checkbox } from '@material-ui/core';
 
 export const AddBlogDialog = () => {
   const { register, errors, handleSubmit, reset } = useForm<FormValues>({
     mode: 'onBlur',
   });
-  const [tag, setTag] = useState<string[]>([]);
-  const [isPrivate, setIsPrivate] = useState(false);
   const user = auth.currentUser;
   const setToast = useSetRecoilState(toastState);
+  const [tag, setTag] = useState<string[]>([]);
+  const [isPrivate, setIsPrivate] = useState(false);
   const [publicCategory, setPublicCategory] = useState('');
+  const [priority, setPriority] = useState<'0' | '1' | '2' | '3' | null>(null);
 
   const onSubmit = async (data: FormValues) => {
     try {
@@ -40,6 +41,7 @@ export const AddBlogDialog = () => {
         postedUser: user?.uid,
         postedAt: firebase.firestore.Timestamp.now(),
         isDone: false,
+        priority: priority ? parseInt(priority) : 2,
       });
 
       const res = await db.collection('tags').get();
@@ -49,6 +51,7 @@ export const AddBlogDialog = () => {
       setTag([]);
       setIsPrivate(false);
       reset();
+      setPriority('0');
     } catch (error) {
       console.log(error);
       setToast(['追加に失敗しました', 'error']);
@@ -96,16 +99,12 @@ export const AddBlogDialog = () => {
       ))}
       <CategorySelector setPublicCategory={setPublicCategory} />
       <Tag tag={tag} setTag={setTag} />
-      <Label>
+      {user && (
         <label css="display: flex">
-          <LabelText>非公開</LabelText>
-          <Checkbox
-            color="primary"
-            checked={isPrivate}
-            onChange={(e) => setIsPrivate(e.target.checked)}
-          />
+          <PrivateCheck {...{ isPrivate, setIsPrivate }} />
+          <PrioritySelector {...{ priority, setPriority }} />
         </label>
-      </Label>
+      )}
     </DialogBase>
   );
 };

--- a/root/components/AddCategoryDialog.tsx
+++ b/root/components/AddCategoryDialog.tsx
@@ -50,7 +50,7 @@ export const AddCategoryDialog = () => {
       }
       await db.collection(`users/${user?.uid}/myCategory`).add({
         name: data.category,
-        imageUrl: '',
+        imageUrl,
       });
       setToast(['追加出来ました！']);
       reset();

--- a/root/components/LoadingButton.tsx
+++ b/root/components/LoadingButton.tsx
@@ -1,7 +1,7 @@
-import { Button, CircularProgress } from '@material-ui/core';
 import React, { FC } from 'react';
 import styled from 'styled-components';
 import { COLOR } from '../../styles/color';
+import { Button, CircularProgress } from '@material-ui/core';
 
 type Props = {
   loading?: boolean;

--- a/root/components/PrioritySelector.tsx
+++ b/root/components/PrioritySelector.tsx
@@ -1,0 +1,32 @@
+import React, { FC } from 'react';
+import { Label, LabelText } from '../../styles/common';
+import { FormControl, Select } from '@material-ui/core';
+
+type Props = {
+  priority: '0' | '1' | '2' | '3' | null;
+  setPriority: (param: '0' | '1' | '2' | '3' | null) => void;
+};
+
+export const PrioritySelector: FC<Props> = ({ priority, setPriority }) => {
+  return (
+    <Label>
+      <FormControl>
+        <label css="display: flex">
+          <LabelText>優先度</LabelText>
+          <Select
+            native
+            onChange={(e) => {
+              setPriority(e.target.value as '0' | '1' | '2' | '3');
+            }}
+            value={priority}
+          >
+            <option value={0}>選択してください</option>
+            <option value={1}>低</option>
+            <option value={2}>普通</option>
+            <option value={3}>高</option>
+          </Select>
+        </label>
+      </FormControl>
+    </Label>
+  );
+};

--- a/root/components/PrioritySelector.tsx
+++ b/root/components/PrioritySelector.tsx
@@ -1,32 +1,31 @@
 import React, { FC } from 'react';
+import { PriorityType } from '../../types';
 import { Label, LabelText } from '../../styles/common';
 import { FormControl, Select } from '@material-ui/core';
 
 type Props = {
-  priority: '0' | '1' | '2' | '3' | null;
-  setPriority: (param: '0' | '1' | '2' | '3' | null) => void;
+  priority: PriorityType;
+  setPriority: (param: PriorityType) => void;
 };
 
-export const PrioritySelector: FC<Props> = ({ priority, setPriority }) => {
-  return (
-    <Label>
-      <FormControl>
-        <label css="display: flex">
-          <LabelText>優先度</LabelText>
-          <Select
-            native
-            onChange={(e) => {
-              setPriority(e.target.value as '0' | '1' | '2' | '3');
-            }}
-            value={priority}
-          >
-            <option value={0}>選択してください</option>
-            <option value={1}>低</option>
-            <option value={2}>普通</option>
-            <option value={3}>高</option>
-          </Select>
-        </label>
-      </FormControl>
-    </Label>
-  );
-};
+export const PrioritySelector: FC<Props> = ({ priority, setPriority }) => (
+  <Label>
+    <FormControl>
+      <label css="display: flex">
+        <LabelText>優先度</LabelText>
+        <Select
+          native
+          onChange={(e) => {
+            setPriority(e.target.value as PriorityType);
+          }}
+          value={priority}
+        >
+          <option value={0}>選択してください</option>
+          <option value={1}>低</option>
+          <option value={2}>普通</option>
+          <option value={3}>高</option>
+        </Select>
+      </label>
+    </FormControl>
+  </Label>
+);

--- a/root/components/PrivateCheck.tsx
+++ b/root/components/PrivateCheck.tsx
@@ -1,0 +1,23 @@
+import React, { FC } from 'react';
+import { Checkbox } from '@material-ui/core';
+import { Label, LabelText } from '../../styles/common';
+
+type Props = {
+  isPrivate: boolean;
+  setIsPrivate: (param: boolean) => void;
+};
+
+export const PrivateCheck: FC<Props> = ({ isPrivate, setIsPrivate }) => {
+  return (
+    <Label>
+      <label css="display: flex">
+        <LabelText>非公開</LabelText>
+        <Checkbox
+          color="primary"
+          checked={isPrivate}
+          onChange={(e) => setIsPrivate(e.target.checked)}
+        />
+      </label>
+    </Label>
+  );
+};

--- a/root/components/PrivateCheck.tsx
+++ b/root/components/PrivateCheck.tsx
@@ -7,17 +7,15 @@ type Props = {
   setIsPrivate: (param: boolean) => void;
 };
 
-export const PrivateCheck: FC<Props> = ({ isPrivate, setIsPrivate }) => {
-  return (
-    <Label>
-      <label css="display: flex">
-        <LabelText>非公開</LabelText>
-        <Checkbox
-          color="primary"
-          checked={isPrivate}
-          onChange={(e) => setIsPrivate(e.target.checked)}
-        />
-      </label>
-    </Label>
-  );
-};
+export const PrivateCheck: FC<Props> = ({ isPrivate, setIsPrivate }) => (
+  <Label>
+    <label css="display: flex">
+      <LabelText>非公開</LabelText>
+      <Checkbox
+        color="primary"
+        checked={isPrivate}
+        onChange={(e) => setIsPrivate(e.target.checked)}
+      />
+    </label>
+  </Label>
+);

--- a/root/components/RecommendRegisterDialog.tsx
+++ b/root/components/RecommendRegisterDialog.tsx
@@ -11,11 +11,13 @@ export const RecommendRegisterDialog = () => {
       <p>ログインするとこんな機能が使えます</p>
       <div css="display: flex">
         <ol>
-          <li>ブログを書いて、それを共有できます</li>
           <li>お気に入りの記事を保存できます</li>
+          <li>他のユーザーのお気に入り記事を保存できます</li>
+          <li>お気に入りの記事を整理できます</li>
         </ol>
         <img
-          src="https://wired.jp/app/uploads/2018/01/GettyImages-522585140.jpg"
+          src="https://firebasestorage.googleapis.com/v0/b/blogfavo.appspot.com/o/Bibliophile-pana.png?alt=media&token=afd3a2d9-ad4a-4dcc-94dc-289fd998e114"
+          // src="https://wired.jp/app/uploads/2018/01/GettyImages-522585140.jpg"
           alt="マスコットキャラクターの写真"
           width="300px"
           height="200px"

--- a/root/components/SettingMenu.tsx
+++ b/root/components/SettingMenu.tsx
@@ -33,7 +33,7 @@ export const SettingMenu: FC<Props> = ({ open, onClose }) => {
       id="simple-menu"
       keepMounted
       anchorEl={open}
-      open={Boolean(open)}
+      open={!!open}
       onClose={onClose}
     >
       <MenuItem>Profile</MenuItem>

--- a/root/pages/main/components/BlogItem.tsx
+++ b/root/pages/main/components/BlogItem.tsx
@@ -4,7 +4,6 @@ import { auth, db } from '../../../utils/firebase';
 import { useSetRecoilState } from 'recoil';
 import { dialogData, RECOMMEND_REGISTER } from '../../../../recoil/dialog';
 import styled from 'styled-components';
-import { COLOR } from '../../../../styles/color';
 import { DeleteButton } from '../../../components/DeleteButton';
 //material
 import {
@@ -19,13 +18,12 @@ import {
   Tooltip,
 } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
-import { purple } from '@material-ui/core/colors';
 import StarBorderRoundedIcon from '@material-ui/icons/StarBorderRounded';
 import TurnedInNotRoundedIcon from '@material-ui/icons/TurnedInNotRounded';
 import StarRoundedIcon from '@material-ui/icons/StarRounded';
 import BookmarkRoundedIcon from '@material-ui/icons/BookmarkRounded';
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   card: {
     height: '100%',
     display: 'flex',

--- a/root/pages/main/components/CategoryItem.tsx
+++ b/root/pages/main/components/CategoryItem.tsx
@@ -75,7 +75,7 @@ export const CategoryItem: FC<Props> = ({
       setCurrentPage('myCategoryBlog');
       setSelectCategory(name);
     } else {
-      return setToast(['ブログはありません', 'error']);
+      return setToast(['ブログはありません', 'warning']);
     }
   };
 

--- a/root/pages/main/index.tsx
+++ b/root/pages/main/index.tsx
@@ -21,7 +21,7 @@ import { Grid } from '@material-ui/core';
 
 const Main: FC = () => {
   const user = auth.currentUser;
-  const blog = useCollection<FormValues>('blog');
+  const blog = useOrderby<FormValues>('blog', 'favCount', 'desc');
   const myCategory = useOrderby<Category>(
     `users/${user?.uid}/myCategory`,
     'name',

--- a/root/pages/main/index.tsx
+++ b/root/pages/main/index.tsx
@@ -3,7 +3,7 @@ import { useRecoilValue, useRecoilState } from 'recoil';
 import { Category, FormValues } from '../../../types';
 import firebase, { db, auth } from '../../utils/firebase';
 import { currentDisplayData, activeDisplayData } from '../../../recoil/root';
-import { useCollection } from '../../utils/hooks';
+import { useCollection, useOrderby } from '../../utils/hooks';
 import {
   ADD_BLOG,
   ADD_CATEGORY,
@@ -22,8 +22,12 @@ import { Grid } from '@material-ui/core';
 const Main: FC = () => {
   const user = auth.currentUser;
   const blog = useCollection<FormValues>('blog');
-  const myCategory = useCollection<Category>(`users/${user?.uid}/myCategory`);
-  const categoryList = useCollection<Category>('categoryList');
+  const myCategory = useOrderby<Category>(
+    `users/${user?.uid}/myCategory`,
+    'name',
+    'asc'
+  );
+  const categoryList = useOrderby<Category>('categoryList', 'name', 'asc');
   const currentDisplay = useRecoilValue(currentDisplayData);
   const [activePage, setActivePage] = useRecoilState(activeDisplayData);
   const [onlyMyBlog, setOnlyMyBlog] = useState<FormValues[]>([]);
@@ -32,6 +36,7 @@ const Main: FC = () => {
   useEffect(() => {
     if (user) {
       db.collection('blog')
+        .orderBy('priority', 'desc')
         .where('postedUser', '==', user.uid)
         .onSnapshot((snap) => {
           const docData = snap.docs.map((doc) => {

--- a/root/utils/hooks/index.ts
+++ b/root/utils/hooks/index.ts
@@ -1,1 +1,3 @@
 export { useCollection } from './useCollection';
+export { useFirebase } from './useFirebase';
+export { useOrderby } from './useOrderby';

--- a/root/utils/hooks/useOrderby.ts
+++ b/root/utils/hooks/useOrderby.ts
@@ -1,0 +1,24 @@
+import { useState, useEffect } from 'react';
+import { db } from '../firebase';
+
+export const useOrderby = <T>(
+  path: string,
+  item: string,
+  order: 'desc' | 'asc'
+) => {
+  const [state, setState] = useState<T[]>([]);
+  useEffect(() => {
+    db.collection(path)
+      .orderBy(item, order)
+      .onSnapshot((res) => {
+        const data = res.docs.map((doc) => {
+          return {
+            ...(doc.data() as T),
+            id: doc.id,
+          };
+        });
+        setState(data);
+      });
+  }, []);
+  return state;
+};

--- a/types.tsx
+++ b/types.tsx
@@ -1,5 +1,7 @@
 import firebase from './root/utils/firebase';
 
+export type PriorityType = '0' | '1' | '2' | '3' | null;
+
 export type FormValues = {
   title: string;
   url: string;
@@ -14,7 +16,7 @@ export type FormValues = {
   favCount: number;
   otherUserBlogId?: string;
   isDone: boolean;
-  priority: '0' | '1' | '2' | '3' | null;
+  priority: PriorityType;
 };
 
 export type Tags = {

--- a/types.tsx
+++ b/types.tsx
@@ -14,6 +14,7 @@ export type FormValues = {
   favCount: number;
   otherUserBlogId?: string;
   isDone: boolean;
+  priority: '0' | '1' | '2' | '3' | null;
 };
 
 export type Tags = {


### PR DESCRIPTION
## Issue

Closes #78


## 今回の PR で行ったこと

- 優先度セレクターの追加
- myPageのブログは優先度順に並び替え
- カテゴリーも名前順に並び替え
- userPageのブログリストをfavCount順に並び替え

## 動作確認(どのような動作確認を行ったのか？ 結果はどうか？)

- 追加、編集モーダルにセレクターが表示されるか -> ok

## 影響範囲(行った作業によってどこまで影響が及ぶようになるか)

- addBlogModal
- blogedit

## 実装するにあたって参考にした URL

- 

## 確認して欲しいこと

- ブログ追加時に非登録の場合は非表示チェックボックス と優先度セレクターをださないようにしました(登録したら編集で変更できる為)

## 懸念点

- 



